### PR TITLE
Fix LWF.prototype.destroy raises DOM Exception 8

### DIFF
--- a/coffee/webkitcss/lwf_webkitcss_resourcecache.coffee
+++ b/coffee/webkitcss/lwf_webkitcss_resourcecache.coffee
@@ -444,8 +444,9 @@ class WebkitCSSResourceCache
   unloadLWF:(lwf) ->
     cache = @cache[lwf.url]
     if cache? and --cache.instances <= 0
-      head = document.getElementsByTagName('head')[0]
-      head.removeChild(cache.script)
+      if cache.data.useScript
+        head = document.getElementsByTagName('head')[0]
+        head.removeChild(cache.script)
       delete @cache[lwf.url]
     return
 


### PR DESCRIPTION
LWF.prototype.destroy raises DOM Exception 8.

The exception is raised by this line.
https://github.com/gree/lwf/blob/faa9bc9a4f3f1bfa47d6e2721008516c4e38df08/coffee/webkitcss/lwf_webkitcss_resourcecache.coffee#L448

Because, LWF did not load script if data.useScript is false.
https://github.com/gree/lwf/blob/faa9bc9a4f3f1bfa47d6e2721008516c4e38df08/coffee/webkitcss/lwf_webkitcss_resourcecache.coffee#L125
