### PR TITLE
Fix memory leak when destroying assets that use a font renderer

### DIFF
--- a/csharp/unity/renderer/common/lwf_unity_text.cs
+++ b/csharp/unity/renderer/common/lwf_unity_text.cs
@@ -285,6 +285,12 @@ public class UnityTextRenderer : TextRenderer
 		m_context.RenderNow(m_renderMatrix, m_colorMult);
 	}
 #endif
+
+	public override void Destruct()
+	{
+		if (m_context != null) m_context.Destruct();
+	}
+
 }
 
 }	// namespace UnityRenderer


### PR DESCRIPTION
The destructor of TextContext was never called.
