### PR TITLE
Fix eventHandlers length was wrong

### DIFF
--- a/coffee/core/lwf_core.coffee
+++ b/coffee/core/lwf_core.coffee
@@ -815,25 +815,25 @@ class LWF
       switch a
         when Animation.END
           return
-  
+
         when Animation.PLAY
           target.play()
-  
+
         when Animation.STOP
           target.stop()
-  
+
         when Animation.NEXTFRAME
           target.nextFrame()
-  
+
         when Animation.PREVFRAME
           target.prevFrame()
-  
+
         when Animation.GOTOFRAME
           target.gotoFrameInternal(animations[i++])
-  
+
         when Animation.GOTOLABEL
           target.gotoFrame(@searchFrame(target, animations[i++]))
-  
+
         when Animation.SETTARGET
           target = movie
 
@@ -854,10 +854,10 @@ class LWF
                   target =
                     target.searchMovieInstanceByInstanceId(instId, false)
                   target = movie unless target?
-  
+
         when Animation.EVENT
           eventId = animations[i++]
-          handlers = @eventHandlers[eventId]
+          handlers = @eventHandlers[eventId]?.slice(0)
           handler(movie, button) for handler in handlers if handlers?
 
         when Animation.CALL


### PR DESCRIPTION
LWF's eventHandlers length become wrong when use this pattern.

```
lwf.addEventHandler('fooEvent', ->
  lwf.removeEventHandler('fooEvent', arguments.callee)
  doSomeThing()
)
```

The handler execute logic gets loop count from eventHandlers.length at before execute loop.
But handler function removes handler from eventHandlers in loop.
https://github.com/gree/lwf/blob/master/coffee/js_debug/lwf.js#L6749

This fix creates clone of eventHandlers by `slice(0)`.
