### PR TITLE
Avoid exception at unloadLWF

### DIFF
--- a/coffee/webkitcss/lwf_webkitcss_resourcecache.coffee
+++ b/coffee/webkitcss/lwf_webkitcss_resourcecache.coffee
@@ -585,8 +585,9 @@ class WebkitCSSResourceCache
         break
       if empty
         try
-          head = document.getElementsByTagName('head')[0]
-          head.removeChild(script) for script in cache.scripts
+          if cache.scripts?
+            head = document.getElementsByTagName('head')[0]
+            head.removeChild(script) for script in cache.scripts
         catch e
           # ignore
         delete @cache[lwf.url]


### PR DESCRIPTION
cache.scripts created if I use foo.lwf.js.
But unloadLWF is called if I use foo.lwf only.

This exception has no problem because it raises in try-catch block.
But I want to avoid detecting exception by Safari's debugger.
