### PR TITLE
Mutual behavior issue in Buttons group

### DIFF
--- a/cplusplus/core/lwf_input.cpp
+++ b/cplusplus/core/lwf_input.cpp
@@ -66,7 +66,8 @@ Button *LWF::InputPoint(int px, int py)
 				if (focus)
 					focus->RollOut();
 				focus = button;
-				focus->RollOver();
+				if (!pressed || pressed == focus)
+					focus->RollOver();
 			}
 			break;
 		}


### PR DESCRIPTION
PRECONDITIONS: we have 2 buttons attached to _root MC.
Both buttons track events: press, release, rollOut, rollOver, - in
order to animate properly the proper events, happening with ‘hit area’.
“Track” means that in .fla source file action script (enclosed in /* as
*/ for LWFS) contains proper handlers, e.g.:
/* as
on(press){
    tellTarget("button_mc"){
        gotoAndPlay("click");
    }
}
on(release){
    tellTarget("button_mc"){
        gotoAndStop("norm");
    }
    fscommand("event","<unique_event_name>");
}
on(rollOver){
    tellTarget("button_mc"){
        gotoAndPlay("click");
    }
}
on(rollOut){
    tellTarget("button_mc"){
        gotoAndStop("norm");
    }
}
*/
User touches 1st button and moves finger off from it (keeping it
touched)

ISSUE DETAILS:
    1. If we want to animate button click state when user gets his
finger back over touched button, but we don’t want other button to be
animated when ‘rollOver’ed (behavior of Apple’s UIKit):
    -  User drags his finger over the 2nd button, and it animates as if
it was touched (the ‘pressed’ object is still the 1st button) - which
is not good. What’s more, if user releases his finger over 2nd button,
‘release’ event according to current logic is not issued for neither of
buttons and the 2nd one remains in ‘clicked’ UI state :)
    2. If we don’t want to handle any rollover, i.e. after the very
first ‘rollOut’ from pressed button we want to consider it as
‘releaseOutside’ed and not to react on any ‘rollOver’:
    - User drags his finger back over the 1st button, and (as we
decided before) we don’t highlight button. But if he releases his
finger at this moment, ‘release’ event is fired (even though the button
was *not* highlighted) - which is not good;

Pull request solves the problem, making group of buttons interact in
mode, described in 1st case (UIKit buttons behavior).

As an alternative, to make buttons behave as it’s described in the 2nd
case, instead of pull requested code we can make the code:
	if (!found && focus) {
		focus->RollOut();
		focus = 0;
	}
(in the same method as pull requested code is) to look like below:
	if (!found && focus) {
		focus->RollOut();
		focus = 0;
		pressed = 0;
	}