### PR TITLE
ClearTextRenderer never called.

### DIFF
--- a/cplusplus/core/lwf_renderer.h
+++ b/cplusplus/core/lwf_renderer.h
@@ -51,7 +51,10 @@ class TextRenderer : public Renderer
 {
 public:
 	TextRenderer(LWF *l) : Renderer(l) {}
-	virtual ~TextRenderer() {}
+	virtual ~TextRenderer() {
+		lwf->ClearTextRenderer(name);
+		Object::Destroy();
+	}
 
 	virtual void SetText(string text) = 0;
 };


### PR DESCRIPTION
void LWFTextTTFRenderer::Destruct()
{
	if (!m_label)
		return;

	cocos2d::LWFNode::removeNodeFromParent(m_label);
	m_label = 0;
}

When removing m_label from parent node no ClearTextRenderer happens. So
that when we call SetText the second time it crashes because SetText
tries to setup string to zomby TextRenderer object.

The solution I see is to call for ClearTextRenderer from parent
distruct:

virtual ~TextRenderer() {
        lwf->ClearTextRenderer(name);
        Object::Destroy();
}