### PR TITLE
LWF object to cocos Node mapping.

### DIFF
--- a/cplusplus/cocos2dx/lwf_cocos2dx_bitmap.cpp
+++ b/cplusplus/cocos2dx/lwf_cocos2dx_bitmap.cpp
@@ -286,7 +286,8 @@ LWFBitmapRenderer::LWFBitmapRenderer(
 		return;
 
 	l->data->resourceCache[filename] = true;
-	node->addChild(m_sprite);
+	int tag = bitmap->parent->instanceId;
+	node->addChild(m_sprite, 0, tag);
 }
 
 LWFBitmapRenderer::LWFBitmapRenderer(
@@ -319,7 +320,8 @@ LWFBitmapRenderer::LWFBitmapRenderer(
 		return;
 
 	l->data->resourceCache[filename] = true;
-	node->addChild(m_sprite);
+    int tag = bitmap->parent->instanceId;
+    node->addChild(m_sprite, 0, tag);
 }
 
 void LWFBitmapRenderer::Destruct()


### PR DESCRIPTION
Preconditions:

There is a need to create a slider control. For this control to work we
have to support such events as touchMove.

Problem:

TouchMove is not introduced in lwf core therefore I want to use cocos
event listeners.

Solution:

To take control over an element we have to get a cocos node
corresponding to LWF::Movie. So we need kind of mapping between
LWF::Movie and cocos2d Node. Seems like there is no an easy way to find
a connection between LWF object and its cocos representation right now.
One of possible solutions would be to set LWF::Movie’s instanceId as a
tag for proper cocos Node.