### PR TITLE
C++: Fix movie bounds calculation

### DIFF
--- a/cplusplus/core/lwf_movie.cpp
+++ b/cplusplus/core/lwf_movie.cpp
@@ -614,9 +614,9 @@ void Movie::PostUpdate()
 
 	if (m_requestedCalculateBounds) {
 		m_currentBounds.xMin = FLT_MAX;
-		m_currentBounds.xMax = FLT_MIN;
+		m_currentBounds.xMax = -FLT_MAX;
 		m_currentBounds.yMin = FLT_MAX;
-		m_currentBounds.yMax = FLT_MIN;
+		m_currentBounds.yMax = -FLT_MAX;
 
 		Inspect(CalculateBoundsWrapper(this), 0, 0, 0);
 		if (lwf->property->hasMatrix) {
@@ -632,12 +632,13 @@ void Movie::PostUpdate()
 				px, py, m_currentBounds.xMax, m_currentBounds.yMax, &invert);
 			m_currentBounds.xMax = px;
 			m_currentBounds.yMax = py;
-			m_bounds = m_currentBounds;
-			m_requestedCalculateBounds = false;
-			if (m_calculateBoundsCallback) {
-				m_calculateBoundsCallback(this);
-				m_calculateBoundsCallback = 0;
-			}
+		}
+
+		m_bounds = m_currentBounds;
+		m_requestedCalculateBounds = false;
+		if (m_calculateBoundsCallback) {
+			m_calculateBoundsCallback(this);
+			m_calculateBoundsCallback = 0;
 		}
 	}
 


### PR DESCRIPTION
1. Fixed scope typo that was probably done when porting HTML5 changes to C++ core (in 9cbcf53). Pay attention to the indentation here: https://github.com/gree/lwf/blob/master/coffee/core/lwf_movie.coffee#L835-843. Because of this issue, RequestCalculateBounds + GetBounds pattern was always returning {0, 0, 0, 0}.
2. FLT_MIN actually returns "minimum normalised **positive** floating-point number" (http://stackoverflow.com/a/7973776) but we actually want to have the smallest negative float instead. This issue led to incorrect bounds calculation when both min and max bound coordinates are negative. HTML5 core has similar code: https://github.com/gree/lwf/blob/master/coffee/core/lwf_movie.coffee#L820-L823