### PR TITLE
issues with text color rendered with cocos2d-x (alpha advancing, text effects)

### DIFF
--- a/cplusplus/cocos2dx/lwf_cocos2dx_textbmfont.cpp
+++ b/cplusplus/cocos2dx/lwf_cocos2dx_textbmfont.cpp
@@ -132,12 +132,18 @@ public:
 		}
 
 		const Color &c = cx->multi;
-		const cocos2d::Color3B &dc = node->getDisplayedColor();
 		setColor({
-			(GLubyte)(c.red * m_red * dc.r),
-			(GLubyte)(c.green * m_green * dc.g),
-			(GLubyte)(c.blue * m_blue * dc.b)});
-		setOpacity((GLubyte)(c.alpha * node->getDisplayedOpacity()));
+            (GLubyte)(c.red * 255),
+            (GLubyte)(c.green * 255),
+            (GLubyte)(c.blue * 255)
+        });
+        setOpacity(c.alpha * 255);
+        setTextColor({
+            (GLubyte)(m_red * 255),
+            (GLubyte)(m_green * 255),
+            (GLubyte)(m_blue * 255),
+            (GLubyte)(255)
+        });
 	}
 
 	void setString(const std::string &label)

--- a/cplusplus/cocos2dx/lwf_cocos2dx_textttf.cpp
+++ b/cplusplus/cocos2dx/lwf_cocos2dx_textttf.cpp
@@ -128,12 +128,18 @@ public:
 		}
 
 		const Color &c = cx->multi;
-		const cocos2d::Color3B &dc = node->getDisplayedColor();
 		setColor({
-			(GLubyte)(c.red * m_red * dc.r),
-			(GLubyte)(c.green * m_green * dc.g),
-			(GLubyte)(c.blue * m_blue * dc.b)});
-		setOpacity((GLubyte)(c.alpha * node->getDisplayedOpacity()));
+			(GLubyte)(c.red * 255),
+			(GLubyte)(c.green * 255),
+			(GLubyte)(c.blue * 255)
+		});
+		setOpacity(c.alpha * 255);
+		setTextColor({
+			(GLubyte)(m_red * 255),
+			(GLubyte)(m_green * 255),
+			(GLubyte)(m_blue * 255),
+			(GLubyte)(255)
+		});
 	}
 
 	virtual void draw(cocos2d::Renderer *renderer,


### PR DESCRIPTION
Fixed: alpha in "Advanced" color effect is ignored
Fixed: color of text affects cocos2d text's effects (outline, shadow)

The main idea of PR is to use ```cocos2d::Label::setTextColor``` to specify text's color, instead of ```setColor``` which changes color of whole label, including effects attached (outline, shadow)

Discussion on cocos2d-x: https://github.com/cocos2d/cocos2d-x/issues/12590

Render examples:
Before
![outline_issue](https://cloud.githubusercontent.com/assets/327778/8407411/ffbaf982-1e6e-11e5-86fb-70c6205de8bd.png)
After:
![outline_issue_fixed](https://cloud.githubusercontent.com/assets/327778/8407396/e0d618e4-1e6e-11e5-93d5-12e1589d05f3.png)