### PR TITLE
C++: Iterate over a copy of event handlers container

### DIFF
--- a/cplusplus/core/lwf_animation.cpp
+++ b/cplusplus/core/lwf_animation.cpp
@@ -102,7 +102,7 @@ void LWF::PlayAnimation(int animationId, Movie *movie, Button *button)
 #if defined(LWF_USE_LUA)
 				CallEventFunctionLua(eventId, movie, button);
 #endif
-				EventHandlerList &v(m_eventHandlers[eventId]);
+				EventHandlerList v(m_eventHandlers[eventId]);
 				EventHandlerList::iterator it(v.begin()), itend(v.end());
 				for (; it != itend; ++it)
 					it->second(movie, button);


### PR DESCRIPTION
Prevents issues that might occur if client code modifies LWF event handlers container in an event handler by calling `RemoveEventHandler`, `ClearEventHandler` of `ClearAllEventHandlers` (while we're still iterating over the container). The behaviour is now similar to `DispatchEvent` implementation in `lwf_event.cpp` where `EventHandlerList` is also copied.