### PR TITLE
fixed to set scaleFactor to one, which is initially set to zero in recent Unity.

### DIFF
--- a/csharp/unity/renderer/common/lwf_unity_text.cs
+++ b/csharp/unity/renderer/common/lwf_unity_text.cs
@@ -144,6 +144,7 @@ public class TextContext
 		s.lineSpacing = lineSpacing;
 		s.horizontalOverflow = HorizontalWrapMode.Wrap;
 		s.verticalOverflow = VerticalWrapMode.Overflow;
+		s.scaleFactor = 1.0f;
 #endif
 		s.color = factory.ConvertColor(data.colors[text.colorId]);
 		s.pivot = new Vector2(-leftMargin, 0);


### PR DESCRIPTION
If scaleFactor is zero, horizontal wrapping happens for every character. This fix corrects the issue.