### PR TITLE
fixed build failure on Cocos2d-x 3.8.0.

### DIFF
--- a/cplusplus/cocos2dx/lwf_cocos2dx_textttf.h
+++ b/cplusplus/cocos2dx/lwf_cocos2dx_textttf.h
@@ -31,11 +31,27 @@ class LWFNode;
 class LWFText : public Label
 {
 public:
+  // NOTE : COCOS2D_VERSION is defined as 0x00030700 in Cocos2d-x 3.8 package.
+  //        Please modify that declaration before using LWF.
+#if 0x00030800 <= COCOS2D_VERSION
+	LWFText(FontAtlas *atlas, TextHAlignment hAlignment)
+		: Label(hAlignment) {
+		setFontAtlas(atlas);
+	}
+	LWFText(FontAtlas *atlas, TextHAlignment hAlignment,
+			TextVAlignment vAlignment)
+		: Label(hAlignment, vAlignment) {
+		setFontAtlas(atlas);
+	}
+#else
 	LWFText(FontAtlas *atlas, TextHAlignment hAlignment)
 		: Label(atlas, hAlignment) {}
 	LWFText(FontAtlas *atlas, TextHAlignment hAlignment,
 			TextVAlignment vAlignment)
 		: Label(atlas, hAlignment, vAlignment) {}
+
+#endif
+
 	virtual ~LWFText() {}
 	virtual LWF::Text *GetText() = 0;
 };


### PR DESCRIPTION
This fix (by @nabeshin) solves the build failure for cocos2d-x 3.8.0 that changes `cocos2d::Label`'s constructor arguments. The current official cocos2d-x 3.8.0 however has wrong `COCOS2D_VERSION` definition so we have to fix it, too, for applying this fix.