### PR TITLE
Fix/uivertex renderer

### DIFF
--- a/csharp/unity/renderer/uivertex/lwf_uivertex_factory.cs
+++ b/csharp/unity/renderer/uivertex/lwf_uivertex_factory.cs
@@ -162,6 +162,7 @@ public class UIVertexComponent : MonoBehaviour
 public partial class Factory : UnityRenderer.Factory
 {
 	public int updateCount;
+	private bool needsUpdate;
 	private int meshComponentNo;
 	private int usedMeshComponentNo;
 	private List<UIVertexComponent> meshComponents;
@@ -229,9 +230,13 @@ public partial class Factory : UnityRenderer.Factory
 		if (parent != null)
 			return;
 
-		updateCount = lwf.updateCount;
-		meshComponentNo = -1;
-		currentMeshComponent = null;
+		needsUpdate = false;
+		if (updateCount != lwf.updateCount) {
+			needsUpdate = true;
+			updateCount = lwf.updateCount;
+			meshComponentNo = -1;
+			currentMeshComponent = null;
+		}
 	}
 
 	public void Render(IMeshRenderer renderer, int rectangleCount,
@@ -241,6 +246,8 @@ public partial class Factory : UnityRenderer.Factory
 			parent.Render(renderer, rectangleCount, material, additionalColor);
 			return;
 		}
+		if (!needsUpdate)
+			return;
 
 		if (currentMeshComponent == null) {
 			meshComponentNo = 0;
@@ -268,6 +275,8 @@ public partial class Factory : UnityRenderer.Factory
 		base.EndRender(lwf);
 
 		if (parent != null)
+			return;
+		if (!needsUpdate)
 			return;
 
 		if (currentMeshComponent == null) {


### PR DESCRIPTION
7490ab0 fixed `updateCount` issue as in https://github.com/gree/lwf/pull/153
13a6a61 derived `UIVertexComponent` from `UnityEngine.UI.Graphic` instead of `MonoBehaviour` and avoided to directly interact with `CanvasRenderer` so that the implementation conforms to uGUI, because the original code doesn't work on Android/iOS devices for Unity 5.2.3 (still works on Editor somehow, though). 