### PR TITLE
modified combinedmesh/uivertex Destruct() to check whether meshComponent is valid.

### DIFF
--- a/csharp/unity/renderer/combinedmesh/lwf_combinedmesh_factory.cs
+++ b/csharp/unity/renderer/combinedmesh/lwf_combinedmesh_factory.cs
@@ -234,7 +234,8 @@ public partial class Factory : UnityRenderer.Factory
 	public override void Destruct()
 	{
 		foreach (CombinedMeshComponent meshComponent in meshComponents)
-			GameObject.Destroy(meshComponent.gameObject);
+			if (meshComponent != null && meshComponent.gameObject != null)
+				GameObject.Destroy(meshComponent.gameObject);
 
 		DestructBitmapContexts();
 		DestructTextContexts();

--- a/csharp/unity/renderer/uivertex/lwf_uivertex_factory.cs
+++ b/csharp/unity/renderer/uivertex/lwf_uivertex_factory.cs
@@ -212,7 +212,8 @@ public partial class Factory : UnityRenderer.Factory
 	public override void Destruct()
 	{
 		foreach (UIVertexComponent meshComponent in meshComponents)
-			GameObject.Destroy(meshComponent.gameObject);
+			if (meshComponent != null && meshComponent.gameObject != null)
+				GameObject.Destroy(meshComponent.gameObject);
 
 		DestructBitmapContexts();
 		DestructTextContexts();


### PR DESCRIPTION
Because meshComponents and corresponding gameObjects may become invalid such as when loading another scene.