### PR TITLE
reverted changes about needsUpdate.

### DIFF
--- a/csharp/unity/renderer/combinedmesh/lwf_combinedmesh_factory.cs
+++ b/csharp/unity/renderer/combinedmesh/lwf_combinedmesh_factory.cs
@@ -201,6 +201,7 @@ public class CombinedMeshComponent : MonoBehaviour
 public partial class Factory : UnityRenderer.Factory
 {
 	public int updateCount;
+	private bool needsUpdate;
 	private int meshComponentNo;
 	private int usedMeshComponentNo;
 	private List<CombinedMeshComponent> meshComponents;
@@ -269,9 +270,13 @@ public partial class Factory : UnityRenderer.Factory
 		if (parent != null)
 			return;
 
-		updateCount = lwf.updateCount;
-		meshComponentNo = -1;
-		currentMeshComponent = null;
+		needsUpdate = false;
+		if (updateCount != lwf.updateCount) {
+			needsUpdate = true;
+			updateCount = lwf.updateCount;
+			meshComponentNo = -1;
+			currentMeshComponent = null;
+		}
 	}
 
 	public void Render(IMeshRenderer renderer, int rectangleCount,
@@ -281,6 +286,8 @@ public partial class Factory : UnityRenderer.Factory
 			parent.Render(renderer, rectangleCount, material, additionalColor);
 			return;
 		}
+		if (!needsUpdate)
+			return;
 
 		if (currentMeshComponent == null) {
 			meshComponentNo = 0;
@@ -308,6 +315,8 @@ public partial class Factory : UnityRenderer.Factory
 		base.EndRender(lwf);
 
 		if (parent != null)
+			return;
+		if (!needsUpdate)
 			return;
 
 		if (currentMeshComponent == null) {

--- a/csharp/unity/renderer/uivertex/lwf_uivertex_factory.cs
+++ b/csharp/unity/renderer/uivertex/lwf_uivertex_factory.cs
@@ -179,6 +179,7 @@ public class UIVertexComponent : UnityEngine.UI.Graphic
 public partial class Factory : UnityRenderer.Factory
 {
 	public int updateCount;
+	private bool needsUpdate;
 	private int meshComponentNo;
 	private int usedMeshComponentNo;
 	private List<UIVertexComponent> meshComponents;
@@ -247,9 +248,13 @@ public partial class Factory : UnityRenderer.Factory
 		if (parent != null)
 			return;
 
-		updateCount = lwf.updateCount;
-		meshComponentNo = -1;
-		currentMeshComponent = null;
+		needsUpdate = false;
+		if (updateCount != lwf.updateCount) {
+			needsUpdate = true;
+			updateCount = lwf.updateCount;
+			meshComponentNo = -1;
+			currentMeshComponent = null;
+		}
 	}
 
 	public void Render(IMeshRenderer renderer, int rectangleCount,
@@ -259,6 +264,8 @@ public partial class Factory : UnityRenderer.Factory
 			parent.Render(renderer, rectangleCount, material, additionalColor);
 			return;
 		}
+		if (!needsUpdate)
+			return;
 
 		if (currentMeshComponent == null) {
 			meshComponentNo = 0;
@@ -286,6 +293,8 @@ public partial class Factory : UnityRenderer.Factory
 		base.EndRender(lwf);
 
 		if (parent != null)
+			return;
+		if (!needsUpdate)
 			return;
 
 		if (currentMeshComponent == null) {


### PR DESCRIPTION
As discussed in https://github.com/gree/lwf/pull/158 . Because https://github.com/gree/lwf/pull/158 fixed updateCount issue in LWFObject, we can use the former "needsUpdate" code.