### PR TITLE
Some refinements for Publish for LWF.jsfl

### DIFF
--- a/tools/flash/Publish for LWF.jsfl
+++ b/tools/flash/Publish for LWF.jsfl
@@ -39,6 +39,8 @@ function warn(msg)
 
 function main()
 {
+	var enableWarningRecompressed = fl.tools.shiftIsDown;
+
 	message = "";
 	fl.outputPanel.clear();
 	fl.showIdleMessage(false);
@@ -114,7 +116,9 @@ function main()
 				if (item.sourceFileExists) {
 					FLfile.copy(item.sourceFilePath, bitmapDir + name);
 				} else {
-					warn("Image \"" + name + "\" recompressed by Flash");
+					if (enableWarningRecompressed) {
+						warn("Image \"" + name + "\" recompressed by Flash");
+					}
 					item.exportToFile(bitmapDir + name);
 				}
 			}

--- a/tools/flash/Publish for LWF.jsfl
+++ b/tools/flash/Publish for LWF.jsfl
@@ -203,7 +203,6 @@ function correctButtonShapeColor(item)
 			var shape = frame.elements[0];
 			if (shape.vertices.length == 4 && shape.contours.length == 2) {
 				var color = shape.contours[1].fill.color;
-warn(color);
 				if (color !== undefined) {
 					var n = parseInt(color.substring(1), 16);
 					if (buttonColors[n] === undefined) {

--- a/tools/flash/Publish for LWF.jsfl
+++ b/tools/flash/Publish for LWF.jsfl
@@ -87,13 +87,13 @@ function main()
 	var libitems = [];
 	for (var i = 0; i < items.length; ++i) {
 		var item = items[i];
-		if (item.name.match(/__IGNORE__/) !== null)
-			continue;
 		switch (item.itemType) {
 		case "bitmap":
 		case "movie clip":
 		case "button":
 			clearLinkage(item);
+			if (item.name.match(/__IGNORE__/) !== null)
+				continue;
 			libitems.push(item);
 		}
 	}


### PR DESCRIPTION
Warnings for recompressed images were introduced at https://github.com/gree/lwfs/issues/7#issuecomment-111559823 . This sometimes results too many warnings for complex contents. d4559c9 suppresses this warning by default but allows a user to enable it by pushing a SHIFT key.